### PR TITLE
update versions and bump project version to 1.6.0

### DIFF
--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>1.5.0</revision>
+    <revision>1.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>1.5.0</revision>
+    <revision>1.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- project properties -->
     <skipShade>false</skipShade>
@@ -31,7 +31,7 @@
     <excludedFailsafeGroups.default>${excludedFailsafeGroups}</excludedFailsafeGroups.default>
     <!-- dependencyManagement versions -->
     <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
-    <spotbugs-annotations.version>4.9.0</spotbugs-annotations.version>
+    <spotbugs-annotations.version>4.9.1</spotbugs-annotations.version>
     <junit.version>5.11.4</junit.version>
     <mockito.version>5.15.2</mockito.version>
     <maven-wrapper.version>3.3.2</maven-wrapper.version>
@@ -46,7 +46,7 @@
     <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>
     <editorconfig-maven-plugin.version>0.1.3</editorconfig-maven-plugin.version> <!-- XXX: Remove linter dependency overrides when upgrading from 0.1.3 -->
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
-    <maven-checkstyle-plugin.checkstyle.version>10.21.2</maven-checkstyle-plugin.checkstyle.version>
+    <maven-checkstyle-plugin.checkstyle.version>10.21.3</maven-checkstyle-plugin.checkstyle.version>
     <maven-pmd-plugin.version>3.26.0</maven-pmd-plugin.version>
     <maven-pmd-plugin.pmd-core.version>7.10.0</maven-pmd-plugin.pmd-core.version>
     <maven-pmd-plugin.pmd-java.version>7.10.0</maven-pmd-plugin.pmd-java.version>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>1.5.0</revision>
+    <revision>1.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- project settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -39,15 +39,15 @@
     <maven-dependency-plugin.version>3.8.1</maven-dependency-plugin.version>
     <maven-release-plugin.version>3.1.1</maven-release-plugin.version>
     <maven-clean-plugin.version>3.4.0</maven-clean-plugin.version>
-    <maven-install-plugin.version>3.1.3</maven-install-plugin.version>
-    <maven-deploy-plugin.version>3.1.3</maven-deploy-plugin.version>
+    <maven-install-plugin.version>3.1.4</maven-install-plugin.version>
+    <maven-deploy-plugin.version>3.1.4</maven-deploy-plugin.version>
     <maven-site-plugin.version>4.0.0-M16</maven-site-plugin.version>
     <!-- additional plugin versions -->
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
-    <flatten-maven-plugin.version>1.6.0</flatten-maven-plugin.version>
+    <flatten-maven-plugin.version>1.7.0</flatten-maven-plugin.version>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
- Bump com.puppycrawl.tools:checkstyle from 10.21.2 to 10.21.3
- Bump org.apache.maven.plugins:maven-deploy-plugin from 3.1.3 to 3.1.4
- Bump com.github.spotbugs:spotbugs-annotations from 4.9.0 to 4.9.1
- Bump org.apache.maven.plugins:maven-install-plugin from 3.1.3 to 3.1.4
- Bump org.codehaus.mojo:flatten-maven-plugin from 1.6.0 to 1.7.0