### PR TITLE
Add new rules to checkstyle.xml for naming conventions and javadocs

### DIFF
--- a/configs/checkstyle.xml
+++ b/configs/checkstyle.xml
@@ -5,6 +5,13 @@
 
 <module name="Checker">
   <module name="SuppressWarningsFilter"/>
+  <module name="JavadocPackage"/>
+
+  <!-- Test Exclusion -->
+  <module name="SuppressionSingleFilter">
+    <property name="files" value="^.*src[\\/]test[\\/]java[\\/].*(IT|Test|Fixture|Mock)\.java$"/>
+    <property name="checks" value="Javadoc|Name"/>
+  </module>
 
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
@@ -36,6 +43,40 @@
       <property name="option" value="bottom"/>
       <property name="sortStaticImportsAlphabetically" value="true"/>
     </module>
+
+    <!-- Naming -->
+    <module name="ParameterName">
+      <property name="format" value="^[a-z][a-zA-Z]+$"/>
+    </module>
+    <module name="MemberName">
+      <property name="format" value="^[a-z][a-zA-Z]+$"/>
+    </module>
+    <module name="MethodTypeParameterName">
+      <property name="format" value="^[A-Z]$"/>
+    </module>
+    <module name="LocalFinalVariableName">
+      <property name="format" value="^[a-z][a-zA-Z]+$"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="LocalFinalVariableName"/>
+      <!-- Matches every identifier 'e' inside any 'catch' clause -->
+      <property name="query" value="//LITERAL_CATCH//descendant::IDENT[@text='e']"/>
+    </module>
+    <module name="CatchParameterName"/>
+    <module name="ConstantName">
+      <property name="format" value="^[A-Z]+(_[A-Z]+)*$"/>
+    </module>
+
+    <!-- Javadocs -->
+    <module name="JavadocLeadingAsteriskAlign"/>
+    <module name="JavadocMissingLeadingAsterisk"/>
+    <module name="JavadocMissingWhitespaceAfterAsterisk"/>
+    <module name="JavadocType"/>
+    <module name="JavadocVariable"/>
+    <module name="MissingJavadocPackage"/>
+    <module name="MissingJavadocMethod"/>
+    <module name="MissingJavadocType"/>
+    <module name="RequireEmptyLineBeforeBlockTagGroup"/>
 
     <!-- Modifiers -->
     <module name="ModifierOrder"/>

--- a/configs/pmd-ruleset.xml
+++ b/configs/pmd-ruleset.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 
-<ruleset name="Custom Rules" 
+<ruleset name="Custom Rules"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
@@ -79,7 +79,7 @@
 
   <rule ref="category/java/codestyle.xml/AtLeastOneConstructor">
     <properties>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
@@ -92,7 +92,7 @@
     <properties>
       <property name="violationSuppressXPath"
                 value="//ancestor::ClassDeclaration[pmd-java:hasAnnotation('org.junit.jupiter.api.Nested')]"/>
-      <property name="testClassPattern" value="^[A-Z][a-zA-Z0-9]*(IT|Test|Fixture)$"/>
+      <property name="testClassPattern" value="^[A-Z][a-zA-Z0-9]*(IT|Test|Fixture|Mock)$"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier">
@@ -132,7 +132,7 @@
   <rule ref="category/java/codestyle.xml/LambdaCanBeMethodReference"/>
   <rule ref="category/java/codestyle.xml/LinguisticNaming">
     <properties>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention"/>
@@ -159,7 +159,7 @@
   <rule ref="category/java/codestyle.xml/ShortVariable"/>
   <rule ref="category/java/codestyle.xml/TooManyStaticImports">
     <properties>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/codestyle.xml/TypeParameterNamingConventions"/>
@@ -223,7 +223,7 @@
   <rule ref="category/java/design.xml/TooManyFields"/>
   <rule ref="category/java/design.xml/TooManyMethods">
     <properties>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/design.xml/UselessOverridingMethod"/>
@@ -233,7 +233,7 @@
   <rule ref="category/java/documentation.xml/CommentContent"/>
   <rule ref="category/java/documentation.xml/CommentRequired">
     <properties>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/documentation.xml/CommentSize">
@@ -261,7 +261,7 @@
   <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals">
     <properties>
       <property name="skipAnnotations" value="true"/>
-      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture)$')]"/>
+      <property name="violationSuppressXPath" value="//ancestor::ClassDeclaration[matches(@SimpleName, '^.*(IT|Test|Fixture|Mock)$')]"/>
     </properties>
   </rule>
   <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier"/>

--- a/configs/pom.xml
+++ b/configs/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>2.5.0</revision>
+    <revision>2.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>2.5.0</revision>
+    <revision>2.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- project properties -->
     <skipShade>false</skipShade>

--- a/versions/pom.xml
+++ b/versions/pom.xml
@@ -27,7 +27,7 @@
 
   <properties>
     <!-- project version -->
-    <revision>2.5.0</revision>
+    <revision>2.6.0</revision>
     <changelist>-SNAPSHOT</changelist>
     <!-- project settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Add new rules to checkstyle.xml for naming conventions and javadocs


- Adjust a pmd rule to match checkstyle
- Bump version to 2.6.0